### PR TITLE
Feature/merkle drop adjust withdraw transaction

### DIFF
--- a/src/js/common/web3.js
+++ b/src/js/common/web3.js
@@ -58,3 +58,7 @@ export async function requestPermission() {
 export async function verifyChainId(chainId) {
   return (await web3.eth.getChainId()) === parseInt(chainId)
 }
+
+export async function getDefaultAccount() {
+  return (await web3.eth.getAccounts())[0]
+}

--- a/src/js/merkle-drop/ClaimFlow.js
+++ b/src/js/merkle-drop/ClaimFlow.js
@@ -111,13 +111,7 @@ function ClaimFlow() {
           setInternalState(STATE.ERROR)
           return
         }
-        return web3.claimTokens(
-          address,
-          amount,
-          proof,
-          handleSign,
-          handleConfirmation
-        )
+        return web3.claimTokens(amount, proof, handleSign, handleConfirmation)
       })
       .catch(error => {
         console.error(error)
@@ -133,7 +127,7 @@ function ClaimFlow() {
           setInternalState(STATE.TRANSACTION_FAILED)
         }
       })
-  }, [address, amount, proof, handleSign, handleConfirmation])
+  }, [amount, proof, handleSign, handleConfirmation])
 
   const reset = useCallback(() => {
     setConfirmations(0)

--- a/src/js/merkle-drop/ClaimFlow.js
+++ b/src/js/merkle-drop/ClaimFlow.js
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from "react"
+import React, { useCallback, useState, useEffect } from "react"
 import * as backend from "./api/backend"
 import { requestPermission } from "../common/web3"
 import * as web3 from "./api/web3"
@@ -15,6 +15,7 @@ import TermsAndConditionsModal from "./components/TermsAndConditionsModal"
 import WaitCard from "./components/WaitCard"
 import ClaimFailed from "./components/ClaimFailed"
 import { useChainState } from "./state/chainState"
+import { useAccountState } from "./state/accountState"
 import ColumnsWrapper from "./components/ColumnsWrapper"
 import ManualProofWrapper from "./components/ManualProofWrapper"
 
@@ -37,6 +38,8 @@ function ClaimFlow() {
   const [currentAmount, setCurrentAmount] = useState("")
   const [amount, setAmount] = useState("")
   const chainState = useChainState()
+  const account = useAccountState()
+  const [addressEqualsAccount, setAddressEqualsAccount] = useState(false)
   const [txHash, setTxHash] = useState("")
   const [confirmations, setConfirmations] = useState(0)
   const [errorMessage, setErrorMessage] = useState("")
@@ -144,6 +147,14 @@ function ClaimFlow() {
     setShowTermsAndConditionsModal(false)
   }
 
+  useEffect(() => {
+    if (!address || !account) {
+      setAddressEqualsAccount(false)
+    } else {
+      setAddressEqualsAccount(address.toLowerCase() === account.toLowerCase())
+    }
+  }, [address, account])
+
   const Headline = () => (
     <div className="has-text-left p-b-lg">
       <h1 className="title">Merkle Drop Token Claim</h1>
@@ -218,6 +229,7 @@ function ClaimFlow() {
               onClaim={openTermsAndConditionsModal}
               reset={reset}
               chainState={chainState}
+              addressEqualsAccount={addressEqualsAccount}
             />
             {showTermsAndConditionsModal && (
               <TermsAndConditionsModal

--- a/src/js/merkle-drop/api/web3.js
+++ b/src/js/merkle-drop/api/web3.js
@@ -1,13 +1,7 @@
 import getWeb3 from "../../common/web3"
 import MerkleDropABI from "../../abi/merkle-drop.json"
 
-export async function claimTokens(
-  address,
-  value,
-  proof,
-  onSign,
-  onConfirmation
-) {
+export async function claimTokens(value, proof, onSign, onConfirmation) {
   const web3 = getWeb3()
   // TODO: Theoretically, web3 could be undefined here. Should not happen, but might. Handle?
   const contract = new web3.eth.Contract(
@@ -16,7 +10,7 @@ export async function claimTokens(
   )
   try {
     return await contract.methods
-      .withdrawFor(address, value, proof)
+      .withdraw(value, proof)
       .send({
         from: (await web3.eth.getAccounts())[0],
       })

--- a/src/js/merkle-drop/components/ClaimAmount.js
+++ b/src/js/merkle-drop/components/ClaimAmount.js
@@ -11,14 +11,16 @@ function ClaimAmount({
   onClaim,
   reset,
   chainState,
+  addressEqualsAccount,
 }) {
   const handleClaim = useCallback(() => {
     onClaim(proof, originalAmount)
   }, [onClaim, proof, originalAmount])
 
   const canClaim =
-    chainState === CHAIN_STATE.CONNECTED ||
-    chainState === CHAIN_STATE.CHAIN_UNKNOWN
+    (chainState === CHAIN_STATE.CONNECTED ||
+      chainState === CHAIN_STATE.CHAIN_UNKNOWN) &&
+    addressEqualsAccount
 
   return (
     <div className="columns is-centered">
@@ -58,6 +60,14 @@ function ClaimAmount({
               We were unable to check the chain you are connected to, please
               make sure you are connected to the&nbsp;
               {process.env.REACT_APP_CHAIN_NAME} before proceeding.
+            </p>
+          )}
+          {!addressEqualsAccount && (
+            <p className="has-text-left has-text-grey">
+              You can only claim the tokens for an account you control.
+              Therefore the transaction sender must equal the address to claim
+              for. Please change the account of your Web3 enabled browser or
+              MetaMask plugin, in order to claim you tokens.
             </p>
           )}
         </div>

--- a/src/js/merkle-drop/state/accountState.js
+++ b/src/js/merkle-drop/state/accountState.js
@@ -1,0 +1,44 @@
+import { useState, useEffect } from "react"
+import getWeb3, { getDefaultAccount } from "../../common/web3"
+
+export function useAccountState() {
+  const [accountState, setAccountState] = useState("")
+
+  useEffect(() => {
+    // box variable to make it available in inner function
+    const env = {
+      checkAccountIntervalId: 0,
+    }
+
+    // define async function because effect function can not be async
+    async function checkAccount() {
+      try {
+        if (getWeb3()) {
+          // function that periodically checks the chain state
+          async function check() {
+            try {
+              setAccountState(await getDefaultAccount())
+            } catch (e) {
+              console.error(e)
+              // Stop the periodical address check
+              clearInterval(env.checkAccountIntervalId)
+              setAccountState(undefined)
+            }
+          }
+
+          env.checkAccountIntervalId = setInterval(check, 500)
+          check()
+        } else {
+          setAccountState(undefined)
+        }
+      } catch (error) {
+        console.log(error)
+        setAccountState(undefined)
+      }
+    }
+
+    checkAccount()
+    return () => clearInterval(env.checkAccountIntervalId)
+  }, [])
+  return accountState
+}


### PR DESCRIPTION
(this is a copy of PR #108 from the private repo)

Closes: #107

Notes:

-  Mark that the first commit includes the minor change to use the withdraw function instead of withdrawFor (which has been removed from the contract).
-   The state related to the signer account follows the scheme of the chain state as suggested within the task planning call.

If you have a better text for the warning message in mind, please feel free to self-actualize yourself. The same goes for new introduced (variable) names.