### PR TITLE
Configure merkle drop in production environment

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -7,3 +7,9 @@ AUCTION_API_URL=/auction-summary.json
 
 # The auction address that's rendered into the auction page
 AUCTION_ADDRESS=0x7255E01F934307FfB7a41FC78B6b1688f5dc6845
+
+# Configure merkle drop
+REACT_APP_API_URL=https://merkle-drop.tlbc.trustlines.foundation/entitlement/
+REACT_APP_CHAIN_NAME=Ethereum Mainnet
+REACT_APP_EXPLORER_URL=https://etherscan.io/
+REACT_APP_CHAIN_ID=1


### PR DESCRIPTION
It's still turned off, but the REACT_APP_API_URL is already the final
one, even though at the moment it's still serving demo data.