### PR TITLE
Extend development configuration for Merkle drop

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -2,6 +2,13 @@
 AUCTION_API_URL=http://localhost:8090/auction-summary
 AUCTION_ADDRESS=0x1A81bc5Bcae26b006f6Fb0b287bb8be8d2FFcF63
 
+# Merkle Drop
+REACT_APP_EXPLORER_URL=https://goerli.etherscan.io/
+REACT_APP_MERKLE_DROP_ADDRESS=0xCde08C9B799B67B5ac7397e76aacAB2515f8D108
+REACT_APP_CHAIN_ID=5
+REACT_APP_CHAIN_NAME=Goerli Test Network
+
+# Newsletter
 REACT_APP_MAILCHIMP_URL=https://foundation.us20.list-manage.com/subscribe/post?u=ad97861a3786f82a87c0c7417&amp;id=a016e5a529
 
 SHOW_MERKLE_DROP=true


### PR DESCRIPTION
Closes: #37

@schmir-at-bb this refers via default configuration (`.env.example`) to a local backend. We should maybe adjust that to the machine for the reviews (see [this issue](https://github.com/trustlines-network/deployment-config/issues/43)). I would leave it up to you and your planned setup to leave this PR open until we have an URL for that machine an refer to that in the config if that is helpful.