### PR TITLE
Clarify whoami

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,6 +54,8 @@ jobs:
       - run:
           name: Build docker preview image
           command: |
+            # The preview website will show the WHOAMI string in the
+            # header (see _header.njk)
             export WHOAMI="${CIRCLE_BRANCH} ${CIRCLE_BUILD_NUM} ${CIRCLE_SHA1}"
             yarn docker-preview
       - run:

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "clean-assets": "del -f ./dist/img/**/* && del -f ./dist/CNAME",
     "format": "eslint ./src/**/*.js ./webpack.*.js --fix",
     "lint": "eslint ./src/**/*.js",
-    "deploy": "yarn run build && gh-pages --dist dist --branch gh-pages"
+    "deploy": "WHOAMI= yarn run build && gh-pages --dist dist --branch gh-pages"
   },
   "husky": {
     "hooks": {

--- a/src/view/layout/_header.njk
+++ b/src/view/layout/_header.njk
@@ -12,6 +12,11 @@
           </a>
       </div>
 
+      {# The following span is used to display additional information
+       # when one serves a preview version of the website. We do set
+       # the WHOAMI environment variable on CircleCI when building an
+       # image meant to be used for previews.
+       #}
       <span style="color:red;font-size:75%;">
             {{ env.WHOAMI}}
       </span>


### PR DESCRIPTION
This clarifies the purpose of the WHOAMI environment variable and makes sure it's empty when deploying to the production page.
