### PR TITLE
add matomo stats to head

### DIFF
--- a/src/view/layout/_base.njk
+++ b/src/view/layout/_base.njk
@@ -18,6 +18,19 @@
         {% block headScripts %}
           <script src="//polyfill.io/v3/polyfill.min.js?flags=gated&features=es6%2Cfetch"></script>
         {% endblock %}
+        <script type="text/javascript">
+          var _paq = window._paq || [];
+          /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+          _paq.push(['trackPageView']);
+          _paq.push(['enableLinkTracking']);
+          (function() {
+            var u="https://stats.trustlines.network/";
+            _paq.push(['setTrackerUrl', u+'matomo.php']);
+            _paq.push(['setSiteId', '6']);
+            var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+            g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+          })();
+        </script>
     </head>
     <body class="{% block bodyClass %}{% endblock %}">
 


### PR DESCRIPTION
Adds Matomo stats javascript to `<head>`. Sends stats to stats.trustlines.network.