### PR TITLE
Skip ci build on gh-pages branch

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "clean-assets": "del -f ./dist/img/**/* && del -f ./dist/CNAME",
     "format": "eslint ./src/**/*.js ./webpack.*.js --fix",
     "lint": "eslint ./src/**/*.js",
-    "deploy": "WHOAMI= yarn run build && gh-pages --dist dist --branch gh-pages"
+    "deploy": "WHOAMI= yarn run build && gh-pages --dist dist --branch gh-pages -m 'Auto commit updates [ci skip]'"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
On gh-pages branch there is no circle ci config so the build ignore will
fail there. This way circle ci should just skip the build based on the
commit message.