### PR TITLE
Feature/enable view contract button

### DIFF
--- a/src/js/auction/bidbox/components/ActionButton.js
+++ b/src/js/auction/bidbox/components/ActionButton.js
@@ -4,7 +4,7 @@ export default function ActionButton(props) {
   return (
     <button
       {...props}
-      className={`button action-button is-rounded is-background-gradient-dark has-text-white {props.className}`}
+      className={`button action-button is-rounded is-background-gradient-dark has-text-white is-button-styled {props.className}`}
     >
       {props.label}
     </button>

--- a/src/js/auction/chart/revealContractAddress.js
+++ b/src/js/auction/chart/revealContractAddress.js
@@ -1,0 +1,70 @@
+import $ from "jquery"
+
+import { SCROLL_THRESHOLD } from "../../common/const"
+
+const auctionContractAddress = $("#address")
+const auctionContractAddressDescription = $("#address-description")
+const revealAuctionContractAddressLink = $("#address-reveal-link")
+const termsAndConditionsModal = $("#terms-and-conditions-modal")
+const termsAndConditionsModalButtonReject = $(
+  "#terms-and-conditions-modal-button-reject"
+)
+const termsAndConditionsModalButtonAccept = $(
+  "#terms-and-conditions-modal-button-accept"
+)
+const termsAndConditionsModalContent = $("#terms-and-conditions-modal-content")
+
+/**
+ * Check if the terms and conditions modal has some overflow that could be
+ * scrolled. This is necessary because depending on the browser font and window
+ * size it could be possible that the whole paragraph is visible. For this
+ * scenario the scroll to bottom rule does not hold true anymore.
+ */
+function checkTermsAndConditionsModalScrollability() {
+  if (!termsAndConditionsModal.hasClass("is-active")) {
+    return
+  }
+
+  const buttonDisabled = termsAndConditionsModalButtonAccept.prop("disabled")
+  const modalIsScrollable =
+    termsAndConditionsModalContent[0].scrollHeight >
+    termsAndConditionsModalContent[0].clientHeight
+
+  if (buttonDisabled && !modalIsScrollable) {
+    termsAndConditionsModalButtonAccept.prop("disabled", false)
+  }
+}
+
+export default function initModal() {
+  // Must be set once in the beginning to be stable.
+  // Do not work properly with plain HTML
+  termsAndConditionsModalButtonAccept.prop("disabled", true)
+
+  window.addEventListener("resize", checkTermsAndConditionsModalScrollability)
+
+  revealAuctionContractAddressLink.click(() => {
+    termsAndConditionsModal.addClass("is-active")
+    checkTermsAndConditionsModalScrollability()
+  })
+
+  termsAndConditionsModalContent.scroll(() => {
+    if (
+      termsAndConditionsModalContent[0].scrollHeight -
+        termsAndConditionsModalContent[0].scrollTop <=
+      termsAndConditionsModalContent[0].clientHeight + SCROLL_THRESHOLD
+    ) {
+      termsAndConditionsModalButtonAccept.prop("disabled", false)
+    }
+  })
+
+  termsAndConditionsModalButtonReject.click(() => {
+    termsAndConditionsModal.removeClass("is-active")
+  })
+
+  termsAndConditionsModalButtonAccept.click(() => {
+    termsAndConditionsModal.removeClass("is-active")
+    revealAuctionContractAddressLink.css("display", "none")
+    auctionContractAddress.css("display", "block")
+    auctionContractAddressDescription.css("display", "block")
+  })
+}

--- a/src/js/auction/index.js
+++ b/src/js/auction/index.js
@@ -6,6 +6,7 @@ import ChartState from "./chart/chartState"
 import ReactDOM from "react-dom"
 import React from "react"
 import AuctionApp from "./bidbox/App"
+import initModal from "./chart/revealContractAddress"
 
 $(() => {
   const chartState = new ChartState()
@@ -13,6 +14,7 @@ $(() => {
   initCollapsibles()
   initLegend(chartState)
   initChart(chartState)
+  initModal()
 })
 
 ReactDOM.render(<AuctionApp />, document.getElementById("rootAuctionApp"))

--- a/src/js/common/components/TermsAndConditionsModal.js
+++ b/src/js/common/components/TermsAndConditionsModal.js
@@ -50,7 +50,7 @@ function TermsAndConditionsModal({ onReject, onAccept, children }) {
                 <div className="column is-one-third">
                   <button
                     id="terms-and-conditions-modal-button-reject"
-                    className="button is-rounded has-text-weight-bold is-outlined is-primary is-fullwidth"
+                    className="button is-rounded is-outlined is-primary is-fullwidth is-button-styled"
                     onClick={onReject}
                   >
                     Reject
@@ -59,7 +59,7 @@ function TermsAndConditionsModal({ onReject, onAccept, children }) {
                 <div className="column is-one-third">
                   <button
                     id="terms-and-conditions-modal-button-accept"
-                    className="button is-rounded has-text-weight-bold has-text-white is-background-gradient-dark is-fullwidth"
+                    className="button is-rounded has-text-white is-background-gradient-dark is-fullwidth is-button-styled"
                     onClick={onAccept}
                     disabled={!scrolledToModalBottom}
                   >

--- a/src/sass/auction.sass
+++ b/src/sass/auction.sass
@@ -73,3 +73,7 @@ $bid-price: #74BEE2
 
 .action-button
   min-width: 200px
+
+.is-button-styled
+  font-weight: 600
+  height: 50px

--- a/src/view/auction.njk
+++ b/src/view/auction.njk
@@ -84,7 +84,7 @@
           </div>
           <div class="columns chart-addons">
             <div class="column is-7">
-              <div class="is-rounded button is-background-gradient-dark has-text-white" id="address-reveal-link">Reveal contract address</div>
+              <div class="is-rounded button is-background-gradient-dark has-text-white is-button-styled" id="address-reveal-link">Reveal contract address</div>
               <div id="address">
                 <h5 class="subtitle is-5 has-text-weight-bold is-marginless has-text-primary" >
                   {{ env.AUCTION_ADDRESS }}
@@ -163,12 +163,12 @@
           <div class="container has-text-centered">
             <div class="columns is-centered">
               <div class="column is-one-third">
-                <button id="terms-and-conditions-modal-button-reject" class="button is-rounded has-text-weight-bold is-outlined is-primary is-fullwidth">
+                <button id="terms-and-conditions-modal-button-reject" class="button is-rounded has-text-weight-bold is-outlined is-primary is-fullwidth is-button-styled">
                   Reject
                 </button>
               </div>
               <div class="column is-one-third">
-                <button id="terms-and-conditions-modal-button-accept" class="button is-rounded has-text-weight-bold has-text-white is-background-gradient-dark is-fullwidth">
+                <button id="terms-and-conditions-modal-button-accept" class="button is-rounded has-text-weight-bold has-text-white is-background-gradient-dark is-fullwidth is-button-styled">
                   Accept
                 </button>
               </div>

--- a/src/view/auction.njk
+++ b/src/view/auction.njk
@@ -84,14 +84,14 @@
           </div>
           <div class="columns chart-addons">
             <div class="column is-7">
-              <div class="is-rounded button is-background-gradient-dark has-text-white is-button-styled" id="address-reveal-link">Reveal contract address</div>
+              <div class="is-rounded button is-background-gradient-dark has-text-white is-button-styled" id="address-reveal-link">Reveal Contract address</div>
               <div id="address">
                 <h5 class="subtitle is-5 has-text-weight-bold is-marginless has-text-primary" >
                   {{ env.AUCTION_ADDRESS }}
                 </h5>
-                <p class="has-text-danger m-b-none">Remember to increase the transaction gas.</p>
+                <p class="has-text-danger m-b-none">Do not diretly send eth or tokens to this address.</p>
               </div>
-              <div class="has-text-grey" id="address-description">Contract Address</div>
+              <div class="has-text-grey" id="address-description">Auction contract Address</div>
             </div>
             <div class="column is-5">
               <h5 class="subtitle is-3 has-text-weight-bold is-marginless has-text-primary" id="current-price">


### PR DESCRIPTION
Re enables the button to show contract address. Replace warning message about gas to warn not to send eth / tln to the contract.
based on https://github.com/trustlines-protocol/www.trustlines.foundation/pull/80 because I wanted to see if the buttons had the correct style.